### PR TITLE
Fix ENV Command Format in Dockerfile

### DIFF
--- a/src/product-catalog/Dockerfile
+++ b/src/product-catalog/Dockerfile
@@ -27,5 +27,5 @@ WORKDIR /usr/src/app/
 COPY ./products/ ./products/
 COPY --from=builder /usr/src/app/product-catalog/ ./
 
-ENV PRODUCT_CATALOG_PORT 8088
+ENV PRODUCT_CATALOG_PORT=8088
 ENTRYPOINT [ "./product-catalog" ]


### PR DESCRIPTION
This pull request addresses a warning encountered during the Docker image build process related to the ENV command format in the Dockerfile.

Changes Made:
Updated the ENV command from the legacy format to the recommended format.


**Before:**

`ENV PRODUCT_CATALOG_PORT 8088`

**After:**

`ENV PRODUCT_CATALOG_PORT=8088`

**Reason for Change:**
The previous format triggered a warning indicating that the legacy format should be replaced with the correct syntax. This change ensures compatibility with future Docker versions and eliminates the warning during the build process.

Warning:-
 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 28)

Please review the changes and let me know if there are any questions or further modifications needed.

Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment variable declaration in the container setup. No impact on application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->