### PR TITLE
Update FrontendTracer.ts

### DIFF
--- a/src/frontend/utils/telemetry/FrontendTracer.ts
+++ b/src/frontend/utils/telemetry/FrontendTracer.ts
@@ -6,11 +6,10 @@ import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
-import { Resource, browserDetector } from '@opentelemetry/resources';
+import { Resource } from '@opentelemetry/resources';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { SessionIdProcessor } from './SessionIdProcessor';
-import { detectResourcesSync } from '@opentelemetry/resources/build/src/detect-resources';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 
 const {
@@ -20,12 +19,10 @@ const {
 } = typeof window !== 'undefined' ? window.ENV : {};
 
 const FrontendTracer = () => {
-  let resource = new Resource({
+  const resource = new Resource({
     [SemanticResourceAttributes.SERVICE_NAME]: NEXT_PUBLIC_OTEL_SERVICE_NAME,
   });
 
-  const detectedResources = detectResourcesSync({ detectors: [browserDetector] });
-  resource = resource.merge(detectedResources);
   const provider = new WebTracerProvider({ resource });
 
   provider.addSpanProcessor(new SessionIdProcessor());


### PR DESCRIPTION
code has this import:
import { Resource, browserDetector } from '@opentelemetry/resources';
But the installed package version:
"@opentelemetry/resources": "1.30.1"
does not export browserDetector, so TypeScript fails during next build.